### PR TITLE
RW 105 Fix Rotation Bug with Small Movement Adjustments

### DIFF
--- a/RememberWonder/Assets/Prefabs/Player Character.prefab
+++ b/RememberWonder/Assets/Prefabs/Player Character.prefab
@@ -278,7 +278,7 @@ MonoBehaviour:
   heldObject: {fileID: 0}
   pushPullObject: {fileID: 0}
   rotationSpeed: 20
-  minRotationDistance: 0.5
+  minRotationDistance: 0.001
 --- !u!54 &5864955303093575426
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/RememberWonder/Assets/Scripts/Helpers and Editor Related/UtilFunctions.cs
+++ b/RememberWonder/Assets/Scripts/Helpers and Editor Related/UtilFunctions.cs
@@ -287,7 +287,7 @@ public static class UtilFunctions
     /// <summary>
     /// Returns a vector with the values at <paramref name="index1"/> and <paramref name="index2"/> swapped (XYZ, 012).
     /// </summary>
-    /// <remarks>Will return the vector unchanged if <paramref name="indexToAdjust"/> is invalid (i&lt;0, i&gt;2).</remarks>
+    /// <remarks>Will return the vector unchanged if either index is invalid (i&lt;0, i&gt;2).</remarks>
     public static Vector3 SwapAxes(this Vector3 v, int index1, int index2)
     {
         if (index1 < 0 || index1 > 2) return v;

--- a/RememberWonder/Assets/Scripts/PlayerMovement.cs
+++ b/RememberWonder/Assets/Scripts/PlayerMovement.cs
@@ -179,6 +179,9 @@ public class PlayerMovement : MonoBehaviour
 
         ApplyPullRestrictions(ref direction);
         if (direction == Vector3.zero) return;
+
+        if(direction.sqrMagnitude > minRotationDistance)
+            RotateCharacterModel(direction.normalized);
         
         float percentHeld = direction.magnitude;
 
@@ -195,10 +198,10 @@ public class PlayerMovement : MonoBehaviour
         {
             rb.AddForce(direction * accModifier, ForceMode.Force);
 
-            if (rb.velocity.sqrMagnitude > minRotationDistance)
-            {
-                RotateCharacterModel(rb.velocity);
-            }
+            //if (rb.velocity.sqrMagnitude > minRotationDistance)
+            //{
+            //    RotateCharacterModel(rb.velocity);
+            //}
         }
 
         directionLastFrame = direction;

--- a/RememberWonder/Assets/Scripts/PlayerMovement.cs
+++ b/RememberWonder/Assets/Scripts/PlayerMovement.cs
@@ -89,7 +89,7 @@ public class PlayerMovement : MonoBehaviour
         jumpInProgress = true;
     }
 
-    public void TogglePause() 
+    public void TogglePause()
     {
         if (paused)
         {
@@ -121,7 +121,7 @@ public class PlayerMovement : MonoBehaviour
             {
                 dropLocation.SetActive(true);
             }
-            else 
+            else
             {
                 rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
             }
@@ -173,16 +173,14 @@ public class PlayerMovement : MonoBehaviour
     {
         Vector3 direction = InputHub.Inst.Gameplay.Move.ReadValue<Vector2>();
 
-        direction =
-            Quaternion.LookRotation(Vector3.Cross(cameraPivot.transform.right, Vector3.up))
-            * direction.SwapAxes(1, 2);
+        direction = Quaternion.LookRotation(Vector3.Cross(cameraPivot.transform.right, Vector3.up)) * direction.SwapAxes(1, 2);
+
+        if (direction.sqrMagnitude > minRotationDistance)
+            RotateCharacterModel(direction.normalized);
 
         ApplyPullRestrictions(ref direction);
         if (direction == Vector3.zero) return;
 
-        if(direction.sqrMagnitude > minRotationDistance)
-            RotateCharacterModel(direction.normalized);
-        
         float percentHeld = direction.magnitude;
 
         //If we are not grounded and moving in a significantly different direction (axis delta > deadzone),


### PR DESCRIPTION
Character rotation uses input direction versus rigidbody velocity to determine rotation output. This should feel more responsive to the player. Some controllers with snapback issues (hardware problem) may cause the character to flick backwards after resetting to neutral but I'm not sure if that's something that we should be super worried about if most controllers work fine.